### PR TITLE
feat: Implementa navegação entre telas - Atividade 07

### DIFF
--- a/lib/core/app_routes.dart
+++ b/lib/core/app_routes.dart
@@ -1,0 +1,5 @@
+class AppRoutes {
+  static const String homePage = '/';
+  static const String productsPage = '/products';
+  static const String detailsPage = '/details';
+}

--- a/lib/data/models/product_model.dart
+++ b/lib/data/models/product_model.dart
@@ -2,28 +2,50 @@ class ProductModel {
   final int id;
   final String title;
   final double price;
+  final String description;
+  final String image;
+  final String category;
+  final double ratingRate;
+  final int ratingCount;
   final bool isFavorited;
 
   ProductModel({
     required this.id,
     required this.title,
     required this.price,
+    required this.description,
+    required this.image,
+    required this.category,
+    required this.ratingRate,
+    required this.ratingCount,
     this.isFavorited = false,
   });
 
   factory ProductModel.fromJson(Map<String, dynamic> json) {
+    final rating = json["rating"] as Map<String, dynamic>? ?? {};
     return ProductModel(
       id: json["id"],
       title: json["title"],
-      price: json["price"].toDouble(),
+      price: (json["price"] as num).toDouble(),
+      description: json["description"] ?? '',
+      image: json["image"] ?? '',
+      category: json["category"] ?? '',
+      ratingRate: (rating["rate"] as num?)?.toDouble() ?? 0.0,
+      ratingCount: (rating["count"] as num?)?.toInt() ?? 0,
       isFavorited: false,
     );
   }
+
   factory ProductModel.fromCache(Map<String, dynamic> json) {
     return ProductModel(
       id: json["id"],
       title: json["title"],
-      price: json["price"].toDouble(),
+      price: (json["price"] as num).toDouble(),
+      description: json["description"] ?? '',
+      image: json["image"] ?? '',
+      category: json["category"] ?? '',
+      ratingRate: (json["ratingRate"] as num?)?.toDouble() ?? 0.0,
+      ratingCount: (json["ratingCount"] as num?)?.toInt() ?? 0,
       isFavorited: json["isFavorited"] ?? false,
     );
   }
@@ -33,6 +55,11 @@ class ProductModel {
       "id": id,
       "title": title,
       "price": price,
+      "description": description,
+      "image": image,
+      "category": category,
+      "ratingRate": ratingRate,
+      "ratingCount": ratingCount,
       "isFavorited": isFavorited,
     };
   }
@@ -41,12 +68,22 @@ class ProductModel {
     int? id,
     String? title,
     double? price,
+    String? description,
+    String? image,
+    String? category,
+    double? ratingRate,
+    int? ratingCount,
     bool? isFavorited,
   }) {
     return ProductModel(
       id: id ?? this.id,
       title: title ?? this.title,
       price: price ?? this.price,
+      description: description ?? this.description,
+      image: image ?? this.image,
+      category: category ?? this.category,
+      ratingRate: ratingRate ?? this.ratingRate,
+      ratingCount: ratingCount ?? this.ratingCount,
       isFavorited: isFavorited ?? this.isFavorited,
     );
   }

--- a/lib/data/repositories/product_repository_impl.dart
+++ b/lib/data/repositories/product_repository_impl.dart
@@ -15,6 +15,11 @@ class ProductRepositoryImpl implements ProductRepository {
       id: m.id,
       title: m.title,
       price: m.price,
+      description: m.description,
+      image: m.image,
+      category: m.category,
+      ratingRate: m.ratingRate,
+      ratingCount: m.ratingCount,
       isFavorited: m.isFavorited,
     );
   }

--- a/lib/domain/entities/product.dart
+++ b/lib/domain/entities/product.dart
@@ -2,20 +2,45 @@ class Product {
   final int id;
   final String title;
   final double price;
+  final String description;
+  final String image;
+  final String category;
+  final double ratingRate;
+  final int ratingCount;
   final bool isFavorited;
 
   Product({
     required this.id,
     required this.title,
     required this.price,
+    required this.description,
+    required this.image,
+    required this.category,
+    required this.ratingRate,
+    required this.ratingCount,
     this.isFavorited = false,
   });
 
-  Product copyWith({int? id, String? title, double? price, bool? isFavorited}) {
+  Product copyWith({
+    int? id,
+    String? title,
+    double? price,
+    String? description,
+    String? image,
+    String? category,
+    double? ratingRate,
+    int? ratingCount,
+    bool? isFavorited,
+  }) {
     return Product(
       id: id ?? this.id,
       title: title ?? this.title,
       price: price ?? this.price,
+      description: description ?? this.description,
+      image: image ?? this.image,
+      category: category ?? this.category,
+      ratingRate: ratingRate ?? this.ratingRate,
+      ratingCount: ratingCount ?? this.ratingCount,
       isFavorited: isFavorited ?? this.isFavorited,
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:mobile_arquitetura_02/core/app_routes.dart';
 import 'package:mobile_arquitetura_02/data/datasources/product_cache_datasource.dart';
 import 'package:mobile_arquitetura_02/data/datasources/product_remote_datasource.dart';
 import 'package:mobile_arquitetura_02/data/repositories/product_repository_impl.dart';
+import 'package:mobile_arquitetura_02/presentation/pages/home_page.dart';
+import 'package:mobile_arquitetura_02/presentation/pages/product_detail_page.dart';
 import 'package:mobile_arquitetura_02/presentation/pages/product_page.dart';
 import 'package:mobile_arquitetura_02/presentation/viewmodels/product_viewmodel.dart';
 import 'package:provider/provider.dart';
@@ -23,10 +26,15 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
       create: (_) => ProductViewmodel(repository),
-      child: const MaterialApp(
+      child: MaterialApp(
         debugShowCheckedModeBanner: false,
         title: 'Products',
-        home: ProductPage(),
+        initialRoute: AppRoutes.homePage,
+        routes: {
+          AppRoutes.homePage: (context) => const HomePage(),
+          AppRoutes.productsPage: (context) => const ProductPage(),
+          AppRoutes.detailsPage: (context) => const ProductDetailPage(),
+        },
       ),
     );
   }

--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_arquitetura_02/core/app_routes.dart';
+import 'package:mobile_arquitetura_02/presentation/viewmodels/product_viewmodel.dart';
+import 'package:provider/provider.dart';
+
+class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text("Home")),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.storefront, size: 80, color: Colors.blueGrey),
+            const SizedBox(height: 24),
+            const Text(
+              "Bem-vindo à loja!",
+              style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              "Explore nossos produtos disponíveis.",
+              style: TextStyle(fontSize: 16, color: Colors.grey),
+            ),
+            const SizedBox(height: 32),
+            ElevatedButton.icon(
+              onPressed: () {
+                context.read<ProductViewmodel>().loadProducts();
+                Navigator.pushNamed(context, AppRoutes.productsPage);
+              },
+              icon: const Icon(Icons.shopping_bag),
+              label: const Text("Ver Produtos"),
+              style: ElevatedButton.styleFrom(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 32,
+                  vertical: 14,
+                ),
+                textStyle: const TextStyle(fontSize: 16),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/product_detail_page.dart
+++ b/lib/presentation/pages/product_detail_page.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_arquitetura_02/core/app_routes.dart';
+import 'package:mobile_arquitetura_02/domain/entities/product.dart';
+
+class ProductDetailPage extends StatelessWidget {
+  const ProductDetailPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final product =
+        ModalRoute.of(context)!.settings.arguments as Product;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Detalhes do Produto"),
+        actions: [
+          TextButton.icon(
+            onPressed: () =>
+                Navigator.popUntil(context, ModalRoute.withName(AppRoutes.homePage)),
+            icon: const Icon(Icons.home, color: Colors.white),
+            label: const Text("Início", style: TextStyle(color: Colors.white)),
+          ),
+        ],
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Container(
+                height: 240,
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(12),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withValues(alpha: 0.08),
+                      blurRadius: 8,
+                      offset: const Offset(0, 2),
+                    ),
+                  ],
+                ),
+                padding: const EdgeInsets.all(16),
+                child: Image.network(
+                  product.image,
+                  fit: BoxFit.contain,
+                  errorBuilder: (context, error, stack) =>
+                      const Icon(Icons.broken_image, size: 80),
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            _CategoryBadge(category: product.category),
+            const SizedBox(height: 12),
+            Text(
+              product.title,
+              style: const TextStyle(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Text(
+                  "\$${product.price.toStringAsFixed(2)}",
+                  style: const TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.w700,
+                    color: Colors.green,
+                  ),
+                ),
+                const Spacer(),
+                _RatingBadge(
+                  rate: product.ratingRate,
+                  count: product.ratingCount,
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              "Descrição",
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              product.description,
+              style: const TextStyle(fontSize: 15, height: 1.5),
+            ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: () => Navigator.pop(context),
+                icon: const Icon(Icons.arrow_back),
+                label: const Text("Voltar para produtos"),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CategoryBadge extends StatelessWidget {
+  final String category;
+  const _CategoryBadge({required this.category});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.primaryContainer,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Text(
+        category,
+        style: TextStyle(
+          fontSize: 12,
+          color: Theme.of(context).colorScheme.onPrimaryContainer,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+    );
+  }
+}
+
+class _RatingBadge extends StatelessWidget {
+  final double rate;
+  final int count;
+  const _RatingBadge({required this.rate, required this.count});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const Icon(Icons.star, color: Colors.amber, size: 18),
+        const SizedBox(width: 4),
+        Text(
+          "${rate.toStringAsFixed(1)} ($count)",
+          style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/pages/product_page.dart
+++ b/lib/presentation/pages/product_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:mobile_arquitetura_02/core/app_routes.dart';
 import 'package:mobile_arquitetura_02/presentation/viewmodels/product_viewmodel.dart';
 import 'package:provider/provider.dart';
 
@@ -51,6 +52,11 @@ class ProductPage extends StatelessWidget {
                             color: product.isFavorited ? Colors.green : null,
                           ),
                           onPressed: () => viewmodel.toggleFavorite(product.id),
+                        ),
+                        onTap: () => Navigator.pushNamed(
+                          context,
+                          AppRoutes.detailsPage,
+                          arguments: product,
                         ),
                       ),
                     );


### PR DESCRIPTION
## Summary

- Implementa fluxo completo de navegação: **Home → Produtos → Detalhes**
- Corrige `HomePage` (estava com `body: context`, inválido) adicionando tela de boas-vindas com botão de acesso
- Implementa `ProductDetailPage` com imagem, título, preço, descrição, categoria e avaliação do produto
- Adiciona `onTap` na lista de produtos para navegar à tela de detalhes passando o `Product` como argumento
- Expande entidade `Product` e `ProductModel` com campos `description`, `image`, `category`, `ratingRate`, `ratingCount`
- Adiciona `AppRoutes.detailsPage` e usa constantes em todo o `main.dart`

## Checklist dos requisitos (#5)

### Funcionalidades obrigatórias
- [x] Tela inicial com acesso à listagem de produtos
- [x] Listagem de produtos consumidos da Fake API
- [x] Navegação para tela de detalhes ao clicar em um produto
- [x] Exibição dos dados completos do produto (nome, preço, descrição, imagem)
- [x] Retorno para a tela anterior (`Navigator.pop` via botão + AppBar)

### Desafios opcionais
- [x] Uso de rotas nomeadas (`AppRoutes`)
- [x] Indicador de carregamento (loading spinner)
- [x] Tratamento de erro na requisição da API
- [x] Botão para voltar direto à tela inicial (`Navigator.popUntil`)
- [x] Melhorias visuais na tela de detalhes (card de imagem, badge de categoria, badge de avaliação)
- [x] Exibição de categoria e avaliação do produto

## Test plan

- [ ] Abrir o app → tela Home deve exibir o botão "Ver Produtos"
- [ ] Tocar "Ver Produtos" → navegar para lista com loading, depois produtos carregados
- [ ] Tocar em qualquer produto → abrir detalhes com imagem, preço, descrição, categoria e avaliação
- [ ] Tocar "Voltar para produtos" → retornar à lista
- [ ] Tocar "Início" no AppBar de detalhes → voltar direto à Home
- [ ] Botão de favoritar ainda funciona normalmente na lista

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)