### PR TITLE
feat: Implementa CRUD completo de produtos

### DIFF
--- a/lib/core/app_routes.dart
+++ b/lib/core/app_routes.dart
@@ -2,4 +2,5 @@ class AppRoutes {
   static const String homePage = '/';
   static const String productsPage = '/products';
   static const String detailsPage = '/details';
+  static const String formPage = '/form';
 }

--- a/lib/data/datasources/product_remote_datasource.dart
+++ b/lib/data/datasources/product_remote_datasource.dart
@@ -5,13 +5,12 @@ import 'package:mobile_arquitetura_02/data/models/product_model.dart';
 
 class ProductRemoteDatasource {
   final http.Client client;
+  static const _baseUrl = 'https://fakestoreapi.com/products';
 
   ProductRemoteDatasource(this.client);
 
   Future<List<ProductModel>> getProducts() async {
-    final response = await client.get(
-      Uri.parse('https://fakestoreapi.com/products'),
-    );
+    final response = await client.get(Uri.parse(_baseUrl));
 
     if (response.statusCode != 200) {
       throw Exception('Failed to fetch products: ${response.statusCode}');
@@ -22,5 +21,42 @@ class ProductRemoteDatasource {
     return data
         .map((json) => ProductModel.fromJson(json as Map<String, dynamic>))
         .toList();
+  }
+
+  Future<ProductModel> addProduct(ProductModel product) async {
+    final response = await client.post(
+      Uri.parse(_baseUrl),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(product.toJson()),
+    );
+
+    if (response.statusCode != 200 && response.statusCode != 201) {
+      throw Exception('Failed to add product: ${response.statusCode}');
+    }
+
+    final data = jsonDecode(utf8.decode(response.bodyBytes)) as Map<String, dynamic>;
+    return ProductModel.fromJson({...product.toJson(), 'id': data['id'] ?? product.id});
+  }
+
+  Future<ProductModel> updateProduct(ProductModel product) async {
+    final response = await client.put(
+      Uri.parse('$_baseUrl/${product.id}'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(product.toJson()),
+    );
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to update product: ${response.statusCode}');
+    }
+
+    return product;
+  }
+
+  Future<void> deleteProduct(int id) async {
+    final response = await client.delete(Uri.parse('$_baseUrl/$id'));
+
+    if (response.statusCode != 200) {
+      throw Exception('Failed to delete product: ${response.statusCode}');
+    }
   }
 }

--- a/lib/data/models/product_model.dart
+++ b/lib/data/models/product_model.dart
@@ -50,6 +50,18 @@ class ProductModel {
     );
   }
 
+  Map<String, dynamic> toJson() {
+    return {
+      "id": id,
+      "title": title,
+      "price": price,
+      "description": description,
+      "image": image,
+      "category": category,
+      "rating": {"rate": ratingRate, "count": ratingCount},
+    };
+  }
+
   Map<String, dynamic> toCache() {
     return {
       "id": id,

--- a/lib/data/repositories/product_repository_impl.dart
+++ b/lib/data/repositories/product_repository_impl.dart
@@ -1,6 +1,7 @@
 import 'package:mobile_arquitetura_02/core/errors/failure.dart';
 import 'package:mobile_arquitetura_02/data/datasources/product_cache_datasource.dart';
 import 'package:mobile_arquitetura_02/data/datasources/product_remote_datasource.dart';
+import 'package:mobile_arquitetura_02/data/models/product_model.dart';
 import 'package:mobile_arquitetura_02/domain/entities/product.dart';
 import 'package:mobile_arquitetura_02/domain/repositories/product_repository.dart';
 
@@ -21,6 +22,20 @@ class ProductRepositoryImpl implements ProductRepository {
       ratingRate: m.ratingRate,
       ratingCount: m.ratingCount,
       isFavorited: m.isFavorited,
+    );
+  }
+
+  ProductModel _toModel(Product p) {
+    return ProductModel(
+      id: p.id,
+      title: p.title,
+      price: p.price,
+      description: p.description,
+      image: p.image,
+      category: p.category,
+      ratingRate: p.ratingRate,
+      ratingCount: p.ratingCount,
+      isFavorited: p.isFavorited,
     );
   }
 
@@ -71,5 +86,43 @@ class ProductRepositoryImpl implements ProductRepository {
     cache.save(updatedList);
 
     return Future.value(_toEntity(updated));
+  }
+
+  @override
+  Future<Product> addProduct(Product product) async {
+    final model = _toModel(product);
+    final created = await remote.addProduct(model);
+
+    final cached = List<ProductModel>.from(cache.get() ?? []);
+    cached.add(created);
+    cache.save(cached);
+
+    return _toEntity(created);
+  }
+
+  @override
+  Future<Product> updateProduct(Product product) async {
+    final model = _toModel(product);
+    final updated = await remote.updateProduct(model);
+
+    final cached = cache.get() ?? [];
+    final index = cached.indexWhere((p) => p.id == updated.id);
+
+    if (index != -1) {
+      final updatedList = List<ProductModel>.from(cached);
+      updatedList[index] = updated;
+      cache.save(updatedList);
+    }
+
+    return _toEntity(updated);
+  }
+
+  @override
+  Future<void> deleteProduct(int id) async {
+    await remote.deleteProduct(id);
+
+    final cached = cache.get() ?? [];
+    final updatedList = cached.where((p) => p.id != id).toList();
+    cache.save(updatedList);
   }
 }

--- a/lib/domain/repositories/product_repository.dart
+++ b/lib/domain/repositories/product_repository.dart
@@ -3,4 +3,7 @@ import 'package:mobile_arquitetura_02/domain/entities/product.dart';
 abstract class ProductRepository {
   Future<List<Product>> getProducts();
   Future<Product> toggleFavorite(int productId);
+  Future<Product> addProduct(Product product);
+  Future<Product> updateProduct(Product product);
+  Future<void> deleteProduct(int id);
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:mobile_arquitetura_02/data/datasources/product_remote_datasource
 import 'package:mobile_arquitetura_02/data/repositories/product_repository_impl.dart';
 import 'package:mobile_arquitetura_02/presentation/pages/home_page.dart';
 import 'package:mobile_arquitetura_02/presentation/pages/product_detail_page.dart';
+import 'package:mobile_arquitetura_02/presentation/pages/product_form_page.dart';
 import 'package:mobile_arquitetura_02/presentation/pages/product_page.dart';
 import 'package:mobile_arquitetura_02/presentation/viewmodels/product_viewmodel.dart';
 import 'package:provider/provider.dart';
@@ -34,6 +35,7 @@ class MyApp extends StatelessWidget {
           AppRoutes.homePage: (context) => const HomePage(),
           AppRoutes.productsPage: (context) => const ProductPage(),
           AppRoutes.detailsPage: (context) => const ProductDetailPage(),
+          AppRoutes.formPage: (context) => const ProductFormPage(),
         },
       ),
     );

--- a/lib/presentation/pages/product_detail_page.dart
+++ b/lib/presentation/pages/product_detail_page.dart
@@ -1,19 +1,80 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_arquitetura_02/core/app_routes.dart';
 import 'package:mobile_arquitetura_02/domain/entities/product.dart';
+import 'package:mobile_arquitetura_02/presentation/viewmodels/product_viewmodel.dart';
+import 'package:provider/provider.dart';
 
 class ProductDetailPage extends StatelessWidget {
   const ProductDetailPage({super.key});
 
+  Future<void> _confirmDelete(
+    BuildContext context,
+    ProductViewmodel viewmodel,
+    int productId,
+    String title,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Excluir produto'),
+        content: Text('Deseja excluir "$title"?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancelar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Excluir', style: TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && context.mounted) {
+      final success = await viewmodel.deleteProduct(productId);
+      if (context.mounted) {
+        if (success) {
+          Navigator.popUntil(context, ModalRoute.withName(AppRoutes.productsPage));
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Produto excluído!')),
+          );
+        } else {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(viewmodel.error ?? 'Erro ao excluir'),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    final product =
-        ModalRoute.of(context)!.settings.arguments as Product;
+    final product = ModalRoute.of(context)!.settings.arguments as Product;
+    final viewmodel = context.read<ProductViewmodel>();
 
     return Scaffold(
       appBar: AppBar(
         title: const Text("Detalhes do Produto"),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.edit),
+            tooltip: 'Editar',
+            onPressed: () => Navigator.pushNamed(
+              context,
+              AppRoutes.formPage,
+              arguments: product,
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete),
+            tooltip: 'Excluir',
+            onPressed: () =>
+                _confirmDelete(context, viewmodel, product.id, product.title),
+          ),
           TextButton.icon(
             onPressed: () =>
                 Navigator.popUntil(context, ModalRoute.withName(AppRoutes.homePage)),
@@ -89,13 +150,28 @@ class ProductDetailPage extends StatelessWidget {
               style: const TextStyle(fontSize: 15, height: 1.5),
             ),
             const SizedBox(height: 24),
-            SizedBox(
-              width: double.infinity,
-              child: OutlinedButton.icon(
-                onPressed: () => Navigator.pop(context),
-                icon: const Icon(Icons.arrow_back),
-                label: const Text("Voltar para produtos"),
-              ),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: () => Navigator.pop(context),
+                    icon: const Icon(Icons.arrow_back),
+                    label: const Text("Voltar"),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: ElevatedButton.icon(
+                    onPressed: () => Navigator.pushNamed(
+                      context,
+                      AppRoutes.formPage,
+                      arguments: product,
+                    ),
+                    icon: const Icon(Icons.edit),
+                    label: const Text("Editar"),
+                  ),
+                ),
+              ],
             ),
           ],
         ),

--- a/lib/presentation/pages/product_form_page.dart
+++ b/lib/presentation/pages/product_form_page.dart
@@ -1,0 +1,191 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_arquitetura_02/domain/entities/product.dart';
+import 'package:mobile_arquitetura_02/presentation/viewmodels/product_viewmodel.dart';
+import 'package:provider/provider.dart';
+
+class ProductFormPage extends StatefulWidget {
+  const ProductFormPage({super.key});
+
+  @override
+  State<ProductFormPage> createState() => _ProductFormPageState();
+}
+
+class _ProductFormPageState extends State<ProductFormPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _titleController = TextEditingController();
+  final _priceController = TextEditingController();
+  final _descriptionController = TextEditingController();
+  final _categoryController = TextEditingController();
+  final _imageController = TextEditingController();
+
+  Product? _editingProduct;
+  bool _isLoading = false;
+
+  bool get _isEditing => _editingProduct != null;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (_editingProduct == null) {
+      final args = ModalRoute.of(context)?.settings.arguments;
+      if (args is Product) {
+        _editingProduct = args;
+        _titleController.text = args.title;
+        _priceController.text = args.price.toString();
+        _descriptionController.text = args.description;
+        _categoryController.text = args.category;
+        _imageController.text = args.image;
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _titleController.dispose();
+    _priceController.dispose();
+    _descriptionController.dispose();
+    _categoryController.dispose();
+    _imageController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    if (!_formKey.currentState!.validate()) return;
+
+    setState(() => _isLoading = true);
+
+    final viewmodel = context.read<ProductViewmodel>();
+
+    final product = Product(
+      id: _isEditing ? _editingProduct!.id : 0,
+      title: _titleController.text.trim(),
+      price: double.parse(_priceController.text.trim()),
+      description: _descriptionController.text.trim(),
+      category: _categoryController.text.trim(),
+      image: _imageController.text.trim().isNotEmpty
+          ? _imageController.text.trim()
+          : 'https://via.placeholder.com/150',
+      ratingRate: _isEditing ? _editingProduct!.ratingRate : 0,
+      ratingCount: _isEditing ? _editingProduct!.ratingCount : 0,
+    );
+
+    final bool success;
+    if (_isEditing) {
+      success = await viewmodel.updateProduct(product);
+    } else {
+      success = await viewmodel.addProduct(product);
+    }
+
+    if (!mounted) return;
+    setState(() => _isLoading = false);
+
+    if (success) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            _isEditing ? 'Produto atualizado!' : 'Produto cadastrado!',
+          ),
+        ),
+      );
+      Navigator.pop(context, true);
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(viewmodel.error ?? 'Erro ao salvar produto.'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_isEditing ? 'Editar Produto' : 'Novo Produto'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _titleController,
+                decoration: const InputDecoration(
+                  labelText: 'Nome do produto',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (v) =>
+                    (v == null || v.trim().isEmpty) ? 'Informe o nome' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _priceController,
+                decoration: const InputDecoration(
+                  labelText: 'Preço',
+                  border: OutlineInputBorder(),
+                  prefixText: 'R\$ ',
+                ),
+                keyboardType:
+                    const TextInputType.numberWithOptions(decimal: true),
+                validator: (v) {
+                  if (v == null || v.trim().isEmpty) return 'Informe o preço';
+                  if (double.tryParse(v.trim()) == null) {
+                    return 'Preço inválido';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _descriptionController,
+                decoration: const InputDecoration(
+                  labelText: 'Descrição',
+                  border: OutlineInputBorder(),
+                ),
+                maxLines: 3,
+                validator: (v) =>
+                    (v == null || v.trim().isEmpty) ? 'Informe a descrição' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _categoryController,
+                decoration: const InputDecoration(
+                  labelText: 'Categoria',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (v) =>
+                    (v == null || v.trim().isEmpty) ? 'Informe a categoria' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _imageController,
+                decoration: const InputDecoration(
+                  labelText: 'URL da imagem (opcional)',
+                  border: OutlineInputBorder(),
+                ),
+                keyboardType: TextInputType.url,
+              ),
+              const SizedBox(height: 24),
+              SizedBox(
+                width: double.infinity,
+                height: 48,
+                child: ElevatedButton(
+                  onPressed: _isLoading ? null : _submit,
+                  child: _isLoading
+                      ? const SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : Text(_isEditing ? 'Salvar alterações' : 'Cadastrar'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/product_page.dart
+++ b/lib/presentation/pages/product_page.dart
@@ -6,6 +6,43 @@ import 'package:provider/provider.dart';
 class ProductPage extends StatelessWidget {
   const ProductPage({super.key});
 
+  Future<void> _confirmDelete(
+    BuildContext context,
+    ProductViewmodel viewmodel,
+    int productId,
+    String title,
+  ) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Excluir produto'),
+        content: Text('Deseja excluir "$title"?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancelar'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Excluir', style: TextStyle(color: Colors.red)),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true && context.mounted) {
+      final success = await viewmodel.deleteProduct(productId);
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(success ? 'Produto excluído!' : viewmodel.error ?? 'Erro ao excluir'),
+            backgroundColor: success ? null : Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final viewmodel = context.watch<ProductViewmodel>();
@@ -44,14 +81,44 @@ class ProductPage extends StatelessWidget {
                       child: ListTile(
                         title: Text(product.title),
                         subtitle: Text("\$${product.price}"),
-                        trailing: IconButton(
-                          icon: Icon(
-                            product.isFavorited
-                                ? Icons.favorite
-                                : Icons.favorite_border,
-                            color: product.isFavorited ? Colors.green : null,
-                          ),
-                          onPressed: () => viewmodel.toggleFavorite(product.id),
+                        trailing: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            IconButton(
+                              icon: Icon(
+                                product.isFavorited
+                                    ? Icons.favorite
+                                    : Icons.favorite_border,
+                                color: product.isFavorited ? Colors.green : null,
+                              ),
+                              onPressed: () =>
+                                  viewmodel.toggleFavorite(product.id),
+                            ),
+                            IconButton(
+                              icon: const Icon(Icons.edit, color: Colors.blue),
+                              onPressed: () async {
+                                final updated = await Navigator.pushNamed(
+                                  context,
+                                  AppRoutes.formPage,
+                                  arguments: product,
+                                );
+                                if (updated == true && context.mounted) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(content: Text('Produto atualizado!')),
+                                  );
+                                }
+                              },
+                            ),
+                            IconButton(
+                              icon: const Icon(Icons.delete, color: Colors.red),
+                              onPressed: () => _confirmDelete(
+                                context,
+                                viewmodel,
+                                product.id,
+                                product.title,
+                              ),
+                            ),
+                          ],
                         ),
                         onTap: () => Navigator.pushNamed(
                           context,
@@ -67,9 +134,23 @@ class ProductPage extends StatelessWidget {
           );
         },
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: viewmodel.loadProducts,
-        child: const Icon(Icons.refresh),
+      floatingActionButton: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          FloatingActionButton(
+            heroTag: 'add',
+            onPressed: () => Navigator.pushNamed(context, AppRoutes.formPage),
+            tooltip: 'Novo produto',
+            child: const Icon(Icons.add),
+          ),
+          const SizedBox(height: 12),
+          FloatingActionButton(
+            heroTag: 'refresh',
+            onPressed: viewmodel.loadProducts,
+            tooltip: 'Atualizar',
+            child: const Icon(Icons.refresh),
+          ),
+        ],
       ),
     );
   }

--- a/lib/presentation/viewmodels/product_viewmodel.dart
+++ b/lib/presentation/viewmodels/product_viewmodel.dart
@@ -66,4 +66,51 @@ class ProductViewmodel extends ChangeNotifier {
       notifyListeners();
     }
   }
+
+  Future<bool> addProduct(Product product) async {
+    _error = null;
+    try {
+      final created = await repository.addProduct(product);
+      _products = [..._products, created];
+      notifyListeners();
+      return true;
+    } catch (e) {
+      _error = e.toString();
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<bool> updateProduct(Product product) async {
+    _error = null;
+    try {
+      final updated = await repository.updateProduct(product);
+      final index = _products.indexWhere((p) => p.id == updated.id);
+      if (index != -1) {
+        final copy = List<Product>.from(_products);
+        copy[index] = updated;
+        _products = copy;
+        notifyListeners();
+      }
+      return true;
+    } catch (e) {
+      _error = e.toString();
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<bool> deleteProduct(int id) async {
+    _error = null;
+    try {
+      await repository.deleteProduct(id);
+      _products = _products.where((p) => p.id != id).toList();
+      notifyListeners();
+      return true;
+    } catch (e) {
+      _error = e.toString();
+      notifyListeners();
+      return false;
+    }
+  }
 }


### PR DESCRIPTION
## Resumo

Closes #6

Implementa as operações completas de CRUD (Create, Read, Update, Delete) para produtos, consumindo a FakeStore API REST e refletindo as mudanças em tempo real na interface via `Provider`.

## O que mudou

### Novas funcionalidades
- **`ProductFormPage`** — tela de formulário reutilizável para cadastro e edição; diferenciada pela presença ou ausência de `Product` nos arguments da rota (`/form`)
- **Excluir produto** — botão de exclusão na listagem e na tela de detalhes, com diálogo de confirmação antes de deletar
- **Editar produto** — botão de edição na listagem e na tela de detalhes, abre o formulário pré-preenchido
- **Adicionar produto** — FAB `+` na tela de listagem abre o formulário em branco

### Camada de dados
- `ProductRemoteDatasource` — novos métodos `addProduct`, `updateProduct`, `deleteProduct` (POST/PUT/DELETE na FakeStore API)
- `ProductModel` — método `toJson()` para serialização nas requisições
- `ProductRepository` (interface) — novos contratos `addProduct`, `updateProduct`, `deleteProduct`
- `ProductRepositoryImpl` — implementações que sincronizam o cache local após cada operação remota

### Camada de apresentação
- `ProductViewmodel` — métodos `addProduct`, `updateProduct`, `deleteProduct` com atualização reativa via `notifyListeners`
- `AppRoutes` — nova rota `/form`
- `main.dart` — rota `ProductFormPage` registrada

## Critérios de aceite atendidos

- [x] É possível listar todos os produtos retornados pela API
- [x] É possível cadastrar um novo produto via formulário e visualizá-lo na listagem
- [x] É possível editar um produto existente e ver a atualização refletida na listagem
- [x] É possível excluir um produto com confirmação e vê-lo removido da listagem
- [x] A tela de detalhes exibe todas as informações do produto selecionado
- [x] O formulário de cadastro e edição é a mesma tela, diferenciada pela presença do `id`
- [x] A estrutura de pastas segue a divisão em camadas (`data/`, `domain/`, `presentation/`)

## Para o revisor

- A FakeStore API não persiste dados reais (retorna respostas simuladas), portanto as mudanças são refletidas apenas no cache em memória durante a sessão.
- `flutter analyze` passou sem nenhum aviso ou erro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)